### PR TITLE
Change in TableId behaviour for non default BigQueryClient.

### DIFF
--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -350,11 +350,10 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public boolean delete(TableId tableId) {
-    final TableId completeTableId =
-        tableId.setProjectId(
+    final TableId completeTableId = tableId.setProjectId(
         Strings.isNullOrEmpty(tableId.getProject())
-        ? getOptions().getProjectId()
-        : tableId.getProject()
+            ? getOptions().getProjectId()
+            : tableId.getProject()
     );
     try {
       return runWithRetries(new Callable<Boolean>() {

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -160,8 +160,14 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public Table create(TableInfo tableInfo, TableOption... options) {
+    // More context about why this: https://github.com/googleapis/google-cloud-java/issues/3808
     final com.google.api.services.bigquery.model.Table tablePb =
-        tableInfo.setProjectId(getOptions().getProjectId()).toPb();
+        tableInfo
+            .setProjectId(
+                Strings.isNullOrEmpty(tableInfo.getTableId().getProject())
+                    ? getOptions().getProjectId()
+                    : tableInfo.getTableId().getProject())
+            .toPb();
     final Map<BigQueryRpc.Option, ?> optionsMap = optionMap(options);
     try {
       return Table.fromPb(this,
@@ -345,7 +351,12 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public boolean delete(TableId tableId) {
-    final TableId completeTableId = tableId.setProjectId(getOptions().getProjectId());
+    final TableId completeTableId =
+        tableId.setProjectId(
+        Strings.isNullOrEmpty(tableId.getProject())
+        ? getOptions().getProjectId()
+        : tableId.getProject()
+    );
     try {
       return runWithRetries(new Callable<Boolean>() {
         @Override
@@ -379,8 +390,14 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public Table update(TableInfo tableInfo, TableOption... options) {
+    // More context about why this: https://github.com/googleapis/google-cloud-java/issues/3808
     final com.google.api.services.bigquery.model.Table tablePb =
-        tableInfo.setProjectId(getOptions().getProjectId()).toPb();
+        tableInfo
+            .setProjectId(
+                Strings.isNullOrEmpty(tableInfo.getTableId().getProject())
+                    ? getOptions().getProjectId()
+                    : tableInfo.getTableId().getProject())
+            .toPb();
     final Map<BigQueryRpc.Option, ?> optionsMap = optionMap(options);
     try {
       return Table.fromPb(this,

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -160,7 +160,6 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public Table create(TableInfo tableInfo, TableOption... options) {
-    // More context about why this: https://github.com/googleapis/google-cloud-java/issues/3808
     final com.google.api.services.bigquery.model.Table tablePb =
         tableInfo
             .setProjectId(
@@ -390,7 +389,6 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
   @Override
   public Table update(TableInfo tableInfo, TableOption... options) {
-    // More context about why this: https://github.com/googleapis/google-cloud-java/issues/3808
     final com.google.api.services.bigquery.model.Table tablePb =
         tableInfo
             .setProjectId(

--- a/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -553,6 +553,20 @@ public class BigQueryImplTest {
   }
 
   @Test
+  public void testCreateTableWithoutProject() {
+    TableInfo tableInfo = TABLE_INFO.setProjectId(PROJECT);
+    TableId tableId = TableId.of("", TABLE_ID.getDataset(), TABLE_ID.getTable());
+    tableInfo.toBuilder().setTableId(tableId);
+    EasyMock.expect(bigqueryRpcMock.create(tableInfo.toPb(), EMPTY_RPC_OPTIONS))
+        .andReturn(tableInfo.toPb());
+    EasyMock.replay(bigqueryRpcMock);
+    BigQueryOptions bigQueryOptions = createBigQueryOptionsForProject(PROJECT, rpcFactoryMock);
+    bigquery = bigQueryOptions.getService();
+    Table table = bigquery.create(tableInfo);
+    assertEquals(new Table(bigquery, new TableInfo.BuilderImpl(tableInfo)), table);
+  }
+
+  @Test
   public void testCreateTableWithSelectedFields() {
     Capture<Map<BigQueryRpc.Option, Object>> capturedOptions = Capture.newInstance();
     EasyMock.expect(
@@ -729,6 +743,16 @@ public class BigQueryImplTest {
   }
 
   @Test
+  public void testDeleteTableFromTableIdWithoutProject() {
+    TableId tableId = TableId.of("", TABLE_ID.getDataset(), TABLE_ID.getTable());
+    EasyMock.expect(bigqueryRpcMock.deleteTable(PROJECT, DATASET, TABLE)).andReturn(true);
+    EasyMock.replay(bigqueryRpcMock);
+    BigQueryOptions bigQueryOptions = createBigQueryOptionsForProject(PROJECT, rpcFactoryMock);
+    bigquery = bigQueryOptions.getService();
+    assertTrue(bigquery.delete(tableId)); 
+  }
+
+  @Test
   public void testUpdateTable() {
     TableInfo updatedTableInfo =
         TABLE_INFO.setProjectId(OTHER_PROJECT).toBuilder().setDescription("newDescription").build();
@@ -739,6 +763,20 @@ public class BigQueryImplTest {
     bigquery = bigQueryOptions.getService();
     Table table = bigquery.update(updatedTableInfo);
     assertEquals(new Table(bigquery, new TableInfo.BuilderImpl(updatedTableInfo)), table);
+  }
+
+  @Test
+  public void testUpdateTableWithoutProject() {
+    TableInfo tableInfo = TABLE_INFO.setProjectId(PROJECT);
+    TableId tableId = TableId.of("", TABLE_ID.getDataset(), TABLE_ID.getTable());
+    tableInfo.toBuilder().setTableId(tableId);
+    EasyMock.expect(bigqueryRpcMock.patch(tableInfo.toPb(), EMPTY_RPC_OPTIONS))
+        .andReturn(tableInfo.toPb());
+    EasyMock.replay(bigqueryRpcMock);
+    BigQueryOptions bigQueryOptions = createBigQueryOptionsForProject(PROJECT, rpcFactoryMock);
+    bigquery = bigQueryOptions.getService();
+    Table table = bigquery.update(tableInfo);
+    assertEquals(new Table(bigquery, new TableInfo.BuilderImpl(tableInfo)), table);
   }
 
   @Test


### PR DESCRIPTION
Change in TableId behaviour for non default BigQueryClient project 1.44 -> 1.45 