### PR TITLE
BigQuery: Fixes Support for StandardSQLTypeName in Field.newBuilder(name, type)

### DIFF
--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Field.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Field.java
@@ -242,8 +242,18 @@ public final class Field implements Serializable {
   }
 
   /** Returns a builder for a Field object with given name and type. */
+  public static Builder newBuilder(String name, StandardSQLTypeName type, Field... subFields) {
+    return new Builder().setName(name).setType(LegacySQLTypeName.legacySQLTypeName(type), subFields);
+  }
+
+  /** Returns a builder for a Field object with given name and type. */
   public static Builder newBuilder(String name, LegacySQLTypeName type, FieldList subFields) {
     return new Builder().setName(name).setType(type, subFields);
+  }
+
+  /** Returns a builder for a Field object with given name and type. */
+  public static Builder newBuilder(String name, StandardSQLTypeName type, FieldList subFields) {
+    return new Builder().setName(name).setType(LegacySQLTypeName.legacySQLTypeName(type), subFields);
   }
 
   TableFieldSchema toPb() {

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Field.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Field.java
@@ -125,7 +125,7 @@ public final class Field implements Serializable {
      *     Types</a>
      */
     public Builder setType(StandardSQLTypeName type, Field... subFields) {
-      return setType(type, subFields.length > 0 ? FieldList.of(subFields) : null);
+      return setType(LegacySQLTypeName.legacySQLTypeName(type), subFields.length > 0 ? FieldList.of(subFields) : null);
     }
 
     /**
@@ -162,29 +162,16 @@ public final class Field implements Serializable {
      * Sets the type of the field.
      *
      * @param type BigQuery data type
-     * @param subFields nested schema fields, in case if {@code type} is {@link
-     *     StandardSQLTypeName#STRUCT}, {@code null} otherwise.
-     * @throws IllegalArgumentException if {@code type == StandardSQLTypeName.STRUCT && (subFields
-     *     == null || subFields.isEmpty())} or if {@code type != StandardSQLTypeName.STRUCT &&
-     *     subFields != null}
+     * @param subFields nested schema fields in case if {@code type} is {@link
+     *     StandardSQLTypeName#STRUCT}, empty otherwise
+     * @throws IllegalArgumentException if {@code type == StandardSQLTypeName.STRUCT &&
+     *     subFields.length == 0} or if {@code type != StandardSQLTypeName.STRUCT &&
+     *     subFields.length != 0}
      * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types">Data
      *     Types</a>
      */
     public Builder setType(StandardSQLTypeName type, FieldList subFields) {
-      if (StandardSQLTypeName.STRUCT.equals(type)) {
-        if (subFields == null || subFields.isEmpty()) {
-          throw new IllegalArgumentException(
-              "The " + type + " field must have at least one sub-field");
-        }
-      } else {
-        if (subFields != null) {
-          throw new IllegalArgumentException(
-              "Only " + StandardSQLTypeName.STRUCT + " fields can have sub-fields");
-        }
-      }
-      this.type = LegacySQLTypeName.legacySQLTypeName(type);
-      this.subFields = subFields;
-      return this;
+      return setType(LegacySQLTypeName.legacySQLTypeName(type), subFields);
     }
 
     /** Sets the mode of the field. When not specified {@link Mode#NULLABLE} is used. */

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
@@ -19,6 +19,8 @@ package com.google.cloud.bigquery;
 import com.google.api.core.ApiFunction;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A type used in legacy SQL contexts. NOTE: some contexts use a mix of types; for example, for
@@ -84,6 +86,14 @@ public final class LegacySQLTypeName extends StringEnumValue {
   public static final LegacySQLTypeName RECORD =
       type.createAndRegister("RECORD").setStandardType(StandardSQLTypeName.STRUCT);
 
+  private static Map<StandardSQLTypeName, LegacySQLTypeName> standardToLegacyMap = new HashMap<>();
+
+  static {
+    for (LegacySQLTypeName legacySqlTypeName : LegacySQLTypeName.values()) {
+      standardToLegacyMap.put(legacySqlTypeName.equivalent, legacySqlTypeName);
+    }
+  }
+
   private StandardSQLTypeName equivalent;
 
   private LegacySQLTypeName setStandardType(StandardSQLTypeName equivalent) {
@@ -94,6 +104,10 @@ public final class LegacySQLTypeName extends StringEnumValue {
   /** Provides the standard SQL type name equivalent to this type name. */
   public StandardSQLTypeName getStandardType() {
     return equivalent;
+  }
+
+  public static LegacySQLTypeName legacySQLTypeName(StandardSQLTypeName type) {
+	  return standardToLegacyMap.get(type);
   }
 
   private LegacySQLTypeName(String constant) {

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
@@ -106,6 +106,7 @@ public final class LegacySQLTypeName extends StringEnumValue {
     return equivalent;
   }
 
+  /** Represents LegacySQLTypeName from StandardSQLTypeName */
   public static LegacySQLTypeName legacySQLTypeName(StandardSQLTypeName type) {
 	  return standardToLegacyMap.get(type);
   }

--- a/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldTest.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldTest.java
@@ -54,6 +54,25 @@ public class FieldTest {
           .setMode(FIELD_MODE3)
           .setDescription(FIELD_DESCRIPTION3)
           .build();
+  private static final Field STANDARD_FIELD_SCHEMA1 =
+      Field.newBuilder(FIELD_NAME1, StandardSQLTypeName.STRING)
+          .setMode(FIELD_MODE1)
+          .setDescription(FIELD_DESCRIPTION1)
+          .build();
+  private static final Field STANDARD_FIELD_SCHEMA2 =
+      Field.newBuilder(FIELD_NAME2, StandardSQLTypeName.INT64)
+          .setMode(FIELD_MODE2)
+          .setDescription(FIELD_DESCRIPTION2)
+          .build();
+  private static final Field STANDARD_FIELD_SCHEMA3 =
+      Field.newBuilder(
+              FIELD_NAME3,
+              StandardSQLTypeName.STRUCT,
+              STANDARD_FIELD_SCHEMA1,
+              STANDARD_FIELD_SCHEMA2)
+          .setMode(FIELD_MODE3)
+          .setDescription(FIELD_DESCRIPTION3)
+          .build();
 
   @Test
   public void testToBuilder() {
@@ -67,10 +86,29 @@ public class FieldTest {
   }
 
   @Test
+  public void testToBuilderWithStandardSQLTypeName() {
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA1, STANDARD_FIELD_SCHEMA1.toBuilder().build());
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA2, STANDARD_FIELD_SCHEMA2.toBuilder().build());
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA3, STANDARD_FIELD_SCHEMA3.toBuilder().build());
+    Field field = STANDARD_FIELD_SCHEMA1.toBuilder().setDescription("New Description").build();
+    assertEquals("New Description", field.getDescription());
+    field = field.toBuilder().setDescription(FIELD_DESCRIPTION1).build();
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA1, field);
+  }
+
+  @Test
   public void testToBuilderIncomplete() {
     Field field = Field.of(FIELD_NAME1, FIELD_TYPE1);
     compareFieldSchemas(field, field.toBuilder().build());
     field = Field.of(FIELD_NAME2, FIELD_TYPE3, FIELD_SCHEMA1, FIELD_SCHEMA2);
+    compareFieldSchemas(field, field.toBuilder().build());
+  }
+
+  @Test
+  public void testToBuilderIncompleteWithStandardSQLTypeName() {
+    Field field = Field.of(FIELD_NAME1, FIELD_TYPE1);
+    compareFieldSchemas(field, field.toBuilder().build());
+    field = Field.of(FIELD_NAME2, FIELD_TYPE3, STANDARD_FIELD_SCHEMA1, STANDARD_FIELD_SCHEMA2);
     compareFieldSchemas(field, field.toBuilder().build());
   }
 
@@ -89,10 +127,35 @@ public class FieldTest {
   }
 
   @Test
+  public void testBuilderWithStandardSQLTypeName() {
+    assertEquals(FIELD_NAME1, STANDARD_FIELD_SCHEMA1.getName());
+    assertEquals(FIELD_TYPE1, STANDARD_FIELD_SCHEMA1.getType());
+    assertEquals(FIELD_MODE1, STANDARD_FIELD_SCHEMA1.getMode());
+    assertEquals(FIELD_DESCRIPTION1, STANDARD_FIELD_SCHEMA1.getDescription());
+    assertEquals(null, STANDARD_FIELD_SCHEMA1.getSubFields());
+    assertEquals(FIELD_NAME3, STANDARD_FIELD_SCHEMA3.getName());
+    assertEquals(FIELD_TYPE3, STANDARD_FIELD_SCHEMA3.getType());
+    assertEquals(FIELD_MODE3, STANDARD_FIELD_SCHEMA3.getMode());
+    assertEquals(FIELD_DESCRIPTION3, STANDARD_FIELD_SCHEMA3.getDescription());
+    assertEquals(
+        FieldList.of(STANDARD_FIELD_SCHEMA1, STANDARD_FIELD_SCHEMA2),
+        STANDARD_FIELD_SCHEMA3.getSubFields());
+  }
+
+  @Test
   public void testToAndFromPb() {
     compareFieldSchemas(FIELD_SCHEMA1, Field.fromPb(FIELD_SCHEMA1.toPb()));
     compareFieldSchemas(FIELD_SCHEMA2, Field.fromPb(FIELD_SCHEMA2.toPb()));
     compareFieldSchemas(FIELD_SCHEMA3, Field.fromPb(FIELD_SCHEMA3.toPb()));
+    Field field = Field.newBuilder(FIELD_NAME1, FIELD_TYPE1).build();
+    compareFieldSchemas(field, Field.fromPb(field.toPb()));
+  }
+
+  @Test
+  public void testToAndFromPbWithStandardSQLTypeName() {
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA1, Field.fromPb(STANDARD_FIELD_SCHEMA1.toPb()));
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA2, Field.fromPb(STANDARD_FIELD_SCHEMA2.toPb()));
+    compareFieldSchemas(STANDARD_FIELD_SCHEMA3, Field.fromPb(STANDARD_FIELD_SCHEMA3.toPb()));
     Field field = Field.newBuilder(FIELD_NAME1, FIELD_TYPE1).build();
     compareFieldSchemas(field, Field.fromPb(field.toPb()));
   }


### PR DESCRIPTION
BigQuery: Fixes Support for StandardSQLTypeName in Field.newBuilder(name, type)