### PR TITLE
Bigquery: added RangePartitioning feature to LoadJobConfiguration.

### DIFF
--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LoadJobConfiguration.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LoadJobConfiguration.java
@@ -53,6 +53,7 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
   private final Boolean useAvroLogicalTypes;
   private final Map<String, String> labels;
   private final Long jobTimeoutMs;
+  private final RangePartitioning rangePartitioning;
 
   public static final class Builder extends JobConfiguration.Builder<LoadJobConfiguration, Builder>
       implements LoadConfiguration.Builder {
@@ -75,6 +76,7 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
     private Boolean useAvroLogicalTypes;
     private Map<String, String> labels;
     private Long jobTimeoutMs;
+    private RangePartitioning rangePartitioning;
 
     private Builder() {
       super(Type.LOAD);
@@ -100,6 +102,7 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
       this.useAvroLogicalTypes = loadConfiguration.useAvroLogicalTypes;
       this.labels = loadConfiguration.labels;
       this.jobTimeoutMs = loadConfiguration.jobTimeoutMs;
+      this.rangePartitioning = loadConfiguration.rangePartitioning;
     }
 
     private Builder(com.google.api.services.bigquery.model.JobConfiguration configurationPb) {
@@ -178,6 +181,10 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
       }
       if (configurationPb.getJobTimeoutMs() != null) {
         this.jobTimeoutMs = configurationPb.getJobTimeoutMs();
+      }
+      if (loadConfigurationPb.getRangePartitioning() != null) {
+        this.rangePartitioning =
+            RangePartitioning.fromPb(loadConfigurationPb.getRangePartitioning());
       }
     }
 
@@ -301,6 +308,17 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
       return this;
     }
 
+    /**
+     * Range partitioning specification for this table. Only one of timePartitioning and
+     * rangePartitioning should be specified.
+     *
+     * @param rangePartitioning rangePartitioning or {@code null} for none
+     */
+    public Builder setRangePartitioning(RangePartitioning rangePartitioning) {
+      this.rangePartitioning = rangePartitioning;
+      return this;
+    }
+
     @Override
     public LoadJobConfiguration build() {
       return new LoadJobConfiguration(this);
@@ -326,6 +344,7 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
     this.useAvroLogicalTypes = builder.useAvroLogicalTypes;
     this.labels = builder.labels;
     this.jobTimeoutMs = builder.jobTimeoutMs;
+    this.rangePartitioning = builder.rangePartitioning;
   }
 
   @Override
@@ -428,6 +447,11 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
     return jobTimeoutMs;
   }
 
+  /** Returns the range partitioning specification for this table */
+  public RangePartitioning getRangePartitioning() {
+    return rangePartitioning;
+  }
+
   @Override
   public Builder toBuilder() {
     return new Builder(this);
@@ -452,7 +476,8 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
         .add("clustering", clustering)
         .add("useAvroLogicalTypes", useAvroLogicalTypes)
         .add("labels", labels)
-        .add("jobTimeoutMs", jobTimeoutMs);
+        .add("jobTimeoutMs", jobTimeoutMs)
+        .add("rangePartitioning", rangePartitioning);
   }
 
   @Override
@@ -541,6 +566,9 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
     }
     if (jobTimeoutMs != null) {
       jobConfiguration.setJobTimeoutMs(jobTimeoutMs);
+    }
+    if (rangePartitioning != null) {
+      loadConfigurationPb.setRangePartitioning(rangePartitioning.toPb());
     }
     jobConfiguration.setLoad(loadConfigurationPb);
     return jobConfiguration;

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LoadJobConfiguration.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LoadJobConfiguration.java
@@ -447,7 +447,7 @@ public final class LoadJobConfiguration extends JobConfiguration implements Load
     return jobTimeoutMs;
   }
 
-  /** Returns the range partitioning specification for this table */
+  /** Returns the range partitioning specification for the table */
   public RangePartitioning getRangePartitioning() {
     return rangePartitioning;
   }

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -67,6 +67,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
   private final Clustering clustering;
   private final Long jobTimeoutMs;
   private final Map<String, String> labels;
+  private final RangePartitioning rangePartitioning;
 
   /**
    * Priority levels for a query. If not specified the priority is assumed to be {@link
@@ -114,6 +115,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
     private Clustering clustering;
     private Long jobTimeoutMs;
     private Map<String, String> labels;
+    private RangePartitioning rangePartitioning;
 
     private Builder() {
       super(Type.QUERY);
@@ -144,6 +146,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
       this.clustering = jobConfiguration.clustering;
       this.jobTimeoutMs = jobConfiguration.jobTimeoutMs;
       this.labels = jobConfiguration.labels;
+      this.rangePartitioning = jobConfiguration.rangePartitioning;
     }
 
     private Builder(com.google.api.services.bigquery.model.JobConfiguration configurationPb) {
@@ -232,6 +235,10 @@ public final class QueryJobConfiguration extends JobConfiguration {
       }
       if (configurationPb.getLabels() != null) {
         this.labels = configurationPb.getLabels();
+      }
+      if (queryConfigurationPb.getRangePartitioning() != null) {
+        this.rangePartitioning =
+            RangePartitioning.fromPb(queryConfigurationPb.getRangePartitioning());
       }
     }
 
@@ -561,6 +568,17 @@ public final class QueryJobConfiguration extends JobConfiguration {
       return this;
     }
 
+    /**
+     * Range partitioning specification for this table. Only one of timePartitioning and
+     * rangePartitioning should be specified.
+     *
+     * @param rangePartitioning rangePartitioning or {@code null} for none
+     */
+    public Builder setRangePartitioning(RangePartitioning rangePartitioning) {
+      this.rangePartitioning = rangePartitioning;
+      return this;
+    }
+
     public QueryJobConfiguration build() {
       return new QueryJobConfiguration(this);
     }
@@ -600,6 +618,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
     this.clustering = builder.clustering;
     this.jobTimeoutMs = builder.jobTimeoutMs;
     this.labels = builder.labels;
+    this.rangePartitioning = builder.rangePartitioning;
   }
 
   /**
@@ -779,6 +798,11 @@ public final class QueryJobConfiguration extends JobConfiguration {
     return labels;
   }
 
+  /** Returns the range partitioning specification for the table */
+  public RangePartitioning getRangePartitioning() {
+    return rangePartitioning;
+  }
+
   @Override
   public Builder toBuilder() {
     return new Builder(this);
@@ -809,7 +833,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
         .add("timePartitioning", timePartitioning)
         .add("clustering", clustering)
         .add("jobTimeoutMs", jobTimeoutMs)
-        .add("labels", labels);
+        .add("labels", labels)
+        .add("rangePartitioning", rangePartitioning);
   }
 
   @Override
@@ -843,7 +868,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
         timePartitioning,
         clustering,
         jobTimeoutMs,
-        labels);
+        labels,
+        rangePartitioning);
   }
 
   @Override
@@ -938,6 +964,9 @@ public final class QueryJobConfiguration extends JobConfiguration {
     }
     if (labels != null) {
       configurationPb.setLabels(labels);
+    }
+    if (rangePartitioning != null) {
+      queryConfigurationPb.setRangePartitioning(rangePartitioning.toPb());
     }
     configurationPb.setQuery(queryConfigurationPb);
     return configurationPb;

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RangePartitioning.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RangePartitioning.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import java.io.Serializable;
+
+public final class RangePartitioning implements Serializable {
+
+  private static final long serialVersionUID = 2011646901758026886L;
+  private final String field;
+  private final Range range;
+
+  public static final class Range implements Serializable {
+
+    private static final long serialVersionUID = -7603436109151103007L;
+    private final Long end;
+    private final Long interval;
+    private final Long start;
+
+    private Range(Builder builder) {
+      this.end = builder.end;
+      this.interval = builder.interval;
+      this.start = builder.start;
+    }
+
+    private Range(com.google.api.services.bigquery.model.RangePartitioning.Range range) {
+      this.end = range.getEnd();
+      this.interval = range.getInterval();
+      this.start = range.getStart();
+    }
+
+    /** A builder for {@code Range} objects. */
+    public static final class Builder {
+
+      private Long end;
+      private Long interval;
+      private Long start;
+
+      private Builder() {}
+
+      /** [Required] The end of range partitioning, exclusive. The value may be {@code null}. */
+      public Builder setEnd(Long end) {
+        this.end = end;
+        return this;
+      }
+
+      /** [Required] The width of each interval. The value may be {@code null}. */
+      public Builder setInterval(Long interval) {
+        this.interval = interval;
+        return this;
+      }
+
+      /** [Required] The start of range partitioning, inclusive. The value may be {@code null}. */
+      public Builder setStart(Long start) {
+        this.start = start;
+        return this;
+      }
+
+      /** Creates a {@code Range} object. */
+      public Range build() {
+        return new Range(this);
+      }
+    }
+
+    /** Returns the end of range partitioning. */
+    public Long getEnd() {
+      return end;
+    }
+
+    /** Returns the width of each interval. */
+    public Long getInterval() {
+      return interval;
+    }
+
+    /** Returns the start of range partitioning. */
+    public Long getStart() {
+      return start;
+    }
+
+    /** Returns a builder for a Range object. */
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("end", end)
+          .add("interval", interval)
+          .add("start", start)
+          .toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(end, interval, start);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this
+          || obj != null
+              && obj.getClass().equals(Range.class)
+              && java.util.Objects.equals(toPb(), ((Range) obj).toPb());
+    }
+
+    com.google.api.services.bigquery.model.RangePartitioning.Range toPb() {
+      com.google.api.services.bigquery.model.RangePartitioning.Range range =
+          new com.google.api.services.bigquery.model.RangePartitioning.Range();
+      range.setEnd(end);
+      range.setInterval(interval);
+      range.setStart(start);
+      return range;
+    }
+
+    static Range fromPb(com.google.api.services.bigquery.model.RangePartitioning.Range range) {
+      return new Range(range);
+    }
+  }
+
+  /** A builder for {@code RangePartitioning} objects. */
+  public static final class Builder {
+
+    private String field;
+    private Range range;
+
+    private Builder() {}
+
+    private Builder(RangePartitioning rangePartitioning) {
+      this.field = rangePartitioning.field;
+      this.range = rangePartitioning.range;
+    }
+
+    /**
+     * [Required] The table is partitioned by this field. The field must be a top- level
+     * NULLABLE/REQUIRED field. The only supported type is INTEGER/INT64.
+     *
+     * @param field field or {@code null} for none
+     */
+    public Builder setField(String field) {
+      checkArgument(!isNullOrEmpty(field), "Provided field is null or empty");
+      this.field = field;
+      return this;
+    }
+
+    /**
+     * [Required] Defines the ranges for range partitioning.
+     *
+     * @param range range or {@code null} for none
+     */
+    public Builder setRange(Range range) {
+      this.range = range;
+      return this;
+    }
+
+    /** Creates a {@code RangePartitioning} object. */
+    public RangePartitioning build() {
+      return new RangePartitioning(this);
+    }
+  }
+
+  private RangePartitioning(Builder builder) {
+    this.field = builder.field;
+    this.range = builder.range;
+  }
+
+  private RangePartitioning(
+      com.google.api.services.bigquery.model.RangePartitioning rangePartitioning) {
+    this.field = rangePartitioning.getField();
+    this.range = Range.fromPb(rangePartitioning.getRange());
+  }
+
+  /** Returns the field of range partitioning. */
+  public String getField() {
+    return field;
+  }
+
+  /** Returns the range of range partitioning. */
+  public Range getRange() {
+    return range;
+  }
+
+  /** Returns a builder for a RangePartitioning object */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /** Returns a builder for the {@code RangePartitioning} object. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("field", field).add("range", range).toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(field, range);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj == this
+        || obj != null
+            && obj.getClass().equals(RangePartitioning.class)
+            && java.util.Objects.equals(toPb(), ((RangePartitioning) obj).toPb());
+  }
+
+  com.google.api.services.bigquery.model.RangePartitioning toPb() {
+    com.google.api.services.bigquery.model.RangePartitioning rangePartitioning =
+        new com.google.api.services.bigquery.model.RangePartitioning();
+    rangePartitioning.setField(field);
+    rangePartitioning.setRange(range.toPb());
+    return rangePartitioning;
+  }
+
+  static RangePartitioning fromPb(
+      com.google.api.services.bigquery.model.RangePartitioning rangePartitioning) {
+    return new RangePartitioning(rangePartitioning);
+  }
+}

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/StandardTableDefinition.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/StandardTableDefinition.java
@@ -150,6 +150,12 @@ public abstract class StandardTableDefinition extends TableDefinition {
     public abstract Builder setTimePartitioning(TimePartitioning timePartitioning);
 
     /**
+     * Sets the range partitioning configuration for the table. Only one of timePartitioning and
+     * rangePartitioning should be specified.
+     */
+    public abstract Builder setRangePartitioning(RangePartitioning rangePartitioning);
+
+    /**
      * Set the clustering configuration for the table. If not set, the table is not clustered.
      * Clustering is only available for partitioned tables.
      */
@@ -202,6 +208,13 @@ public abstract class StandardTableDefinition extends TableDefinition {
   public abstract TimePartitioning getTimePartitioning();
 
   /**
+   * Returns the range partitioning configuration for this table. If {@code null}, the table is not
+   * range-partitioned.
+   */
+  @Nullable
+  public abstract RangePartitioning getRangePartitioning();
+
+  /**
    * Returns the clustering configuration for this table. If {@code null}, the table is not
    * clustered.
    */
@@ -240,6 +253,9 @@ public abstract class StandardTableDefinition extends TableDefinition {
     if (getTimePartitioning() != null) {
       tablePb.setTimePartitioning(getTimePartitioning().toPb());
     }
+    if (getRangePartitioning() != null) {
+      tablePb.setRangePartitioning(getRangePartitioning().toPb());
+    }
     if (getClustering() != null) {
       tablePb.setClustering(getClustering().toPb());
     }
@@ -257,6 +273,9 @@ public abstract class StandardTableDefinition extends TableDefinition {
     }
     if (tablePb.getTimePartitioning() != null) {
       builder.setTimePartitioning(TimePartitioning.fromPb(tablePb.getTimePartitioning()));
+    }
+    if (tablePb.getRangePartitioning() != null) {
+      builder.setRangePartitioning(RangePartitioning.fromPb(tablePb.getRangePartitioning()));
     }
     if (tablePb.getClustering() != null) {
       builder.setClustering(Clustering.fromPb(tablePb.getClustering()));

--- a/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/LoadJobConfigurationTest.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/LoadJobConfigurationTest.java
@@ -63,6 +63,10 @@ public class LoadJobConfigurationTest {
   private static final Map<String, String> LABELS =
       ImmutableMap.of("test-job-name", "test-load-job");
   private static final Long TIMEOUT = 10L;
+  private static final RangePartitioning.Range RANGE =
+      RangePartitioning.Range.newBuilder().setStart(1L).setInterval(2L).setEnd(10L).build();
+  private static final RangePartitioning RANGE_PARTITIONING =
+      RangePartitioning.newBuilder().setField("IntegerField").setRange(RANGE).build();
   private static final LoadJobConfiguration LOAD_CONFIGURATION_CSV =
       LoadJobConfiguration.newBuilder(TABLE_ID, SOURCE_URIS)
           .setCreateDisposition(CREATE_DISPOSITION)
@@ -78,7 +82,9 @@ public class LoadJobConfigurationTest {
           .setClustering(CLUSTERING)
           .setLabels(LABELS)
           .setJobTimeoutMs(TIMEOUT)
+          .setRangePartitioning(RANGE_PARTITIONING)
           .build();
+
   private static final DatastoreBackupOptions BACKUP_OPTIONS =
       DatastoreBackupOptions.newBuilder()
           .setProjectionFields(ImmutableList.of("field_1", "field_2"))
@@ -95,6 +101,7 @@ public class LoadJobConfigurationTest {
           .setAutodetect(AUTODETECT)
           .setLabels(LABELS)
           .setJobTimeoutMs(TIMEOUT)
+          .setRangePartitioning(RANGE_PARTITIONING)
           .build();
   private static final LoadJobConfiguration LOAD_CONFIGURATION_AVRO =
       LoadJobConfiguration.newBuilder(TABLE_ID, SOURCE_URIS)
@@ -112,6 +119,7 @@ public class LoadJobConfigurationTest {
           .setUseAvroLogicalTypes(USERAVROLOGICALTYPES)
           .setLabels(LABELS)
           .setJobTimeoutMs(TIMEOUT)
+          .setRangePartitioning(RANGE_PARTITIONING)
           .build();
 
   @Test
@@ -229,5 +237,6 @@ public class LoadJobConfigurationTest {
     assertEquals(expected.getUseAvroLogicalTypes(), value.getUseAvroLogicalTypes());
     assertEquals(expected.getLabels(), value.getLabels());
     assertEquals(expected.getJobTimeoutMs(), value.getJobTimeoutMs());
+    assertEquals(expected.getRangePartitioning(), value.getRangePartitioning());
   }
 }

--- a/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -86,6 +86,10 @@ public class QueryJobConfigurationTest {
   private static final Long TIMEOUT = 10L;
   private static final Map<String, String> LABELS =
       ImmutableMap.of("test-job-name", "test-query-job");
+  private static final RangePartitioning.Range RANGE =
+      RangePartitioning.Range.newBuilder().setStart(1L).setInterval(2L).setEnd(10L).build();
+  private static final RangePartitioning RANGE_PARTITIONING =
+      RangePartitioning.newBuilder().setField("IntegerField").setRange(RANGE).build();
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION =
       QueryJobConfiguration.newBuilder(QUERY)
           .setUseQueryCache(USE_QUERY_CACHE)
@@ -107,6 +111,7 @@ public class QueryJobConfigurationTest {
           .setClustering(CLUSTERING)
           .setJobTimeoutMs(TIMEOUT)
           .setLabels(LABELS)
+          .setRangePartitioning(RANGE_PARTITIONING)
           .build();
 
   @Test
@@ -140,6 +145,7 @@ public class QueryJobConfigurationTest {
     assertNull(QUERY_JOB_CONFIGURATION.toPb().getLoad());
     assertNotNull(QUERY_JOB_CONFIGURATION.getJobTimeoutMs());
     assertNotNull(QUERY_JOB_CONFIGURATION.getLabels());
+    assertNotNull(QUERY_JOB_CONFIGURATION.getRangePartitioning());
     compareQueryJobConfiguration(
         QUERY_JOB_CONFIGURATION, QueryJobConfiguration.fromPb(QUERY_JOB_CONFIGURATION.toPb()));
     QueryJobConfiguration job = QueryJobConfiguration.of(QUERY);
@@ -197,5 +203,6 @@ public class QueryJobConfigurationTest {
     assertEquals(expected.getClustering(), value.getClustering());
     assertEquals(expected.getJobTimeoutMs(), value.getJobTimeoutMs());
     assertEquals(expected.getLabels(), value.getLabels());
+    assertEquals(expected.getRangePartitioning(), value.getRangePartitioning());
   }
 }


### PR DESCRIPTION
These classes and properties add support for the integer range
partitioning feature. These offer more flexibility in partitioning
options than time-based partitioning.

Note: integer range partitioning is currently only available under whitelist.