### PR TITLE
BigQuery: implement scripting support

### DIFF
--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -490,6 +490,11 @@ public interface BigQuery extends Service<BigQueryOptions> {
       return new JobListOption(BigQueryRpc.Option.PAGE_TOKEN, pageToken);
     }
 
+    /** Returns an option to list only child job from specify parent job id. */
+    public static JobListOption parentJobId(String parentJobId) {
+      return new JobListOption(BigQueryRpc.Option.PARENT_JOB_ID, parentJobId);
+    }
+
     /**
      * Returns an option to specify the job's fields to be returned by the RPC call. If this option
      * is not provided all job's fields are returned. {@code JobOption.fields()} can be used to

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
@@ -858,28 +858,54 @@ public abstract class JobStatistics implements Serializable {
         }
       }
 
+      /** Returns the end column. */
       public Integer getEndColumn() {
         return endColumn;
       }
 
+      /** Returns the end line. */
       public Integer getEndLine() {
         return endLine;
       }
 
+      /** Returns Name of the active procedure, empty if in a top-level script. */
       public String getProcedureId() {
         return procedureId;
       }
 
+      /** Returns the start column */
       public Integer getStartColumn() {
         return startColumn;
       }
 
+      /** Returns the start line. */
       public Integer getStartLine() {
         return startLine;
       }
 
+      /** Returns Text of the current statement/expression. */
       public String getText() {
         return text;
+      }
+
+      ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+            .add("endColumn", endColumn)
+            .add("endLine", endLine)
+            .add("procedureId", procedureId)
+            .add("startColumn", startColumn)
+            .add("startLine", startLine)
+            .add("text", text);
+      }
+
+      @Override
+      public String toString() {
+        return toStringHelper().toString();
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(endColumn, endLine, procedureId, startColumn, startLine, text);
       }
 
       com.google.api.services.bigquery.model.ScriptStackFrame toPb() {
@@ -954,12 +980,34 @@ public abstract class JobStatistics implements Serializable {
       return new Builder();
     }
 
+    /** Returns child job was a statement or expression */
     public String getEvaluationKind() {
       return evaluationKind;
     }
 
+    /**
+     * Stack trace showing the line/column/procedure name of each frame on the stack at the point
+     * where the current evaluation happened. The leaf frame is first, the primary script is last.
+     * Never empty.
+     */
     public List<ScriptStackFrame> getStackFrames() {
       return stackFrames;
+    }
+
+    ToStringHelper toStringHelper() {
+      return MoreObjects.toStringHelper(this)
+          .add("evaluationKind", evaluationKind)
+          .add("stackFrames", stackFrames);
+    }
+
+    @Override
+    public String toString() {
+      return toStringHelper().toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(evaluationKind, stackFrames);
     }
 
     com.google.api.services.bigquery.model.ScriptStatistics toPb() {
@@ -1003,7 +1051,7 @@ public abstract class JobStatistics implements Serializable {
       this.numChildJobs = statisticsPb.getNumChildJobs();
       this.parentJobId = statisticsPb.getParentJobId();
       if (statisticsPb.getScriptStatistics() != null) {
-        this.scriptStatistics = ScriptStatistics.fromPb(scriptStatistics.toPb());
+        this.scriptStatistics = ScriptStatistics.fromPb(statisticsPb.getScriptStatistics());
       }
     }
 
@@ -1060,14 +1108,17 @@ public abstract class JobStatistics implements Serializable {
     return startTime;
   }
 
+  /** Returns the number of child job executed. */
   public Long getNumChildJobs() {
     return numChildJobs;
   }
 
+  /** Returns the parent job id of child job. */
   public String getParentJobId() {
     return parentJobId;
   }
 
+  /** Returns the statistics for a child job of a script. */
   public ScriptStatistics getScriptStatistics() {
     return scriptStatistics;
   }
@@ -1104,7 +1155,9 @@ public abstract class JobStatistics implements Serializable {
     statistics.setStartTime(startTime);
     statistics.setNumChildJobs(numChildJobs);
     statistics.setParentJobId(parentJobId);
-    statistics.setScriptStatistics(scriptStatistics.toPb());
+    if (scriptStatistics != null) {
+      statistics.setScriptStatistics(scriptStatistics.toPb());
+    }
     return statistics;
   }
 

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
@@ -21,14 +21,18 @@ import com.google.api.services.bigquery.model.JobConfiguration;
 import com.google.api.services.bigquery.model.JobStatistics2;
 import com.google.api.services.bigquery.model.JobStatistics3;
 import com.google.api.services.bigquery.model.JobStatistics4;
+import com.google.api.services.bigquery.model.ScriptStackFrame;
+import com.google.api.services.bigquery.model.ScriptStatistics;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A Google BigQuery Job statistics. */
 public abstract class JobStatistics implements Serializable {
@@ -38,6 +42,9 @@ public abstract class JobStatistics implements Serializable {
   private final Long creationTime;
   private final Long endTime;
   private final Long startTime;
+  private final Long numChildJobs;
+  private final String parentJobId;
+  private final ScriptStatistics scriptStatistics;
 
   /** A Google BigQuery Copy Job statistics. */
   public static class CopyStatistics extends JobStatistics {
@@ -754,11 +761,238 @@ public abstract class JobStatistics implements Serializable {
     }
   }
 
+  /** A Google BigQuery Script statistics. */
+  public static class ScriptStatistics {
+
+    private static final long serialVersionUID = 1328768324537448161L;
+
+    private final String evaluationKind;
+    private final List<ScriptStackFrame> stackFrames;
+
+    static class ScriptStackFrame {
+
+      static final Function<
+              com.google.api.services.bigquery.model.ScriptStackFrame, ScriptStackFrame>
+          FROM_PB_FUNCTION =
+              new Function<
+                  com.google.api.services.bigquery.model.ScriptStackFrame, ScriptStackFrame>() {
+                @NullableDecl
+                @Override
+                public ScriptStackFrame apply(
+                    @NullableDecl
+                        com.google.api.services.bigquery.model.ScriptStackFrame stackFrame) {
+                  return ScriptStackFrame.fromPb(stackFrame);
+                }
+              };
+
+      static final Function<
+              ScriptStackFrame, com.google.api.services.bigquery.model.ScriptStackFrame>
+          TO_PB_FUNCTION =
+              new Function<
+                  ScriptStackFrame, com.google.api.services.bigquery.model.ScriptStackFrame>() {
+                @NullableDecl
+                @Override
+                public com.google.api.services.bigquery.model.ScriptStackFrame apply(
+                    @NullableDecl ScriptStackFrame scriptStackFrame) {
+                  return scriptStackFrame.toPb();
+                }
+              };
+
+      private final Integer endColumn;
+      private final Integer endLine;
+      private final String procedureId;
+      private final Integer startColumn;
+      private final Integer startLine;
+      private final String text;
+
+      private ScriptStackFrame(Builder builder) {
+        this.endColumn = builder.endColumn;
+        this.endLine = builder.endLine;
+        this.procedureId = builder.procedureId;
+        this.startColumn = builder.startColumn;
+        this.startLine = builder.startLine;
+        this.text = builder.text;
+      }
+
+      static class Builder {
+
+        private Integer endColumn;
+        private Integer endLine;
+        private String procedureId;
+        private Integer startColumn;
+        private Integer startLine;
+        private String text;
+
+        Builder setEndColumn(Integer endColumn) {
+          this.endColumn = endColumn;
+          return this;
+        }
+
+        Builder setEndLine(Integer endLine) {
+          this.endLine = endLine;
+          return this;
+        }
+
+        Builder setProcedureId(String procedureId) {
+          this.procedureId = procedureId;
+          return this;
+        }
+
+        Builder setStartColumn(Integer startColumn) {
+          this.startColumn = startColumn;
+          return this;
+        }
+
+        Builder setStartLine(Integer startLine) {
+          this.startLine = startLine;
+          return this;
+        }
+
+        Builder setText(String text) {
+          this.text = text;
+          return this;
+        }
+
+        ScriptStackFrame build() {
+          return new ScriptStackFrame(this);
+        }
+      }
+
+      public Integer getEndColumn() {
+        return endColumn;
+      }
+
+      public Integer getEndLine() {
+        return endLine;
+      }
+
+      public String getProcedureId() {
+        return procedureId;
+      }
+
+      public Integer getStartColumn() {
+        return startColumn;
+      }
+
+      public Integer getStartLine() {
+        return startLine;
+      }
+
+      public String getText() {
+        return text;
+      }
+
+      com.google.api.services.bigquery.model.ScriptStackFrame toPb() {
+        com.google.api.services.bigquery.model.ScriptStackFrame stackFrame =
+            new com.google.api.services.bigquery.model.ScriptStackFrame();
+        stackFrame.setEndColumn(endColumn);
+        stackFrame.setEndLine(endLine);
+        stackFrame.setProcedureId(procedureId);
+        stackFrame.setStartColumn(startColumn);
+        stackFrame.setStartLine(startLine);
+        stackFrame.setText(text);
+        return stackFrame;
+      }
+
+      static Builder newBuilder() {
+        return new Builder();
+      }
+
+      static ScriptStackFrame fromPb(
+          com.google.api.services.bigquery.model.ScriptStackFrame stackFrame) {
+        Builder builder = newBuilder();
+        if (stackFrame.getEndColumn() != null) {
+          builder.setEndColumn(stackFrame.getEndColumn());
+        }
+        if (stackFrame.getEndLine() != null) {
+          builder.setEndLine(stackFrame.getEndLine());
+        }
+        if (stackFrame.getProcedureId() != null) {
+          builder.setProcedureId(stackFrame.getProcedureId());
+        }
+        if (stackFrame.getStartColumn() != null) {
+          builder.setStartColumn(stackFrame.getStartColumn());
+        }
+        if (stackFrame.getStartLine() != null) {
+          builder.setStartLine(stackFrame.getStartLine());
+        }
+        if (stackFrame.getText() != null) {
+          builder.setText(stackFrame.getText());
+        }
+        return builder.build();
+      }
+    }
+
+    private ScriptStatistics(Builder builder) {
+      this.evaluationKind = builder.evaluationKind;
+      this.stackFrames = builder.stackFrames;
+    }
+
+    static class Builder {
+
+      private String evaluationKind;
+      private List<ScriptStackFrame> stackFrames;
+
+      private Builder() {}
+
+      Builder setEvaluationKind(String evaluationKind) {
+        this.evaluationKind = evaluationKind;
+        return this;
+      }
+
+      Builder setStackFrames(List<ScriptStackFrame> stackFrames) {
+        this.stackFrames = stackFrames;
+        return this;
+      }
+
+      ScriptStatistics build() {
+        return new ScriptStatistics(this);
+      }
+    }
+
+    static Builder newBuilder() {
+      return new Builder();
+    }
+
+    public String getEvaluationKind() {
+      return evaluationKind;
+    }
+
+    public List<ScriptStackFrame> getStackFrames() {
+      return stackFrames;
+    }
+
+    com.google.api.services.bigquery.model.ScriptStatistics toPb() {
+      com.google.api.services.bigquery.model.ScriptStatistics scriptStatistics =
+          new com.google.api.services.bigquery.model.ScriptStatistics();
+      scriptStatistics.setEvaluationKind(evaluationKind);
+      scriptStatistics.setStackFrames(
+          Lists.transform(stackFrames, ScriptStackFrame.TO_PB_FUNCTION));
+      return scriptStatistics;
+    }
+
+    static ScriptStatistics fromPb(
+        com.google.api.services.bigquery.model.ScriptStatistics scriptStatistics) {
+      Builder builder = newBuilder();
+      if (scriptStatistics.getEvaluationKind() != null) {
+        builder.setEvaluationKind(scriptStatistics.getEvaluationKind());
+      }
+      if (scriptStatistics.getStackFrames() != null) {
+        builder.setStackFrames(
+            Lists.transform(scriptStatistics.getStackFrames(), ScriptStackFrame.FROM_PB_FUNCTION));
+      }
+      return builder.build();
+    }
+  }
+
   abstract static class Builder<T extends JobStatistics, B extends Builder<T, B>> {
 
     private Long creationTime;
     private Long endTime;
     private Long startTime;
+    private Long numChildJobs;
+    private String parentJobId;
+    private ScriptStatistics scriptStatistics;
 
     protected Builder() {}
 
@@ -766,6 +1000,11 @@ public abstract class JobStatistics implements Serializable {
       this.creationTime = statisticsPb.getCreationTime();
       this.endTime = statisticsPb.getEndTime();
       this.startTime = statisticsPb.getStartTime();
+      this.numChildJobs = statisticsPb.getNumChildJobs();
+      this.parentJobId = statisticsPb.getParentJobId();
+      if (statisticsPb.getScriptStatistics() != null) {
+        this.scriptStatistics = ScriptStatistics.fromPb(scriptStatistics.toPb());
+      }
     }
 
     @SuppressWarnings("unchecked")
@@ -795,6 +1034,9 @@ public abstract class JobStatistics implements Serializable {
     this.creationTime = builder.creationTime;
     this.endTime = builder.endTime;
     this.startTime = builder.startTime;
+    this.numChildJobs = builder.numChildJobs;
+    this.parentJobId = builder.parentJobId;
+    this.scriptStatistics = builder.scriptStatistics;
   }
 
   /** Returns the creation time of the job in milliseconds since epoch. */
@@ -818,11 +1060,26 @@ public abstract class JobStatistics implements Serializable {
     return startTime;
   }
 
+  public Long getNumChildJobs() {
+    return numChildJobs;
+  }
+
+  public String getParentJobId() {
+    return parentJobId;
+  }
+
+  public ScriptStatistics getScriptStatistics() {
+    return scriptStatistics;
+  }
+
   ToStringHelper toStringHelper() {
     return MoreObjects.toStringHelper(this)
         .add("creationTime", creationTime)
         .add("endTime", endTime)
-        .add("startTime", startTime);
+        .add("startTime", startTime)
+        .add("numChildJobs", numChildJobs)
+        .add("parentJobId", parentJobId)
+        .add("scriptStatistics", scriptStatistics);
   }
 
   @Override
@@ -831,7 +1088,8 @@ public abstract class JobStatistics implements Serializable {
   }
 
   final int baseHashCode() {
-    return Objects.hash(creationTime, endTime, startTime);
+    return Objects.hash(
+        creationTime, endTime, startTime, numChildJobs, parentJobId, scriptStatistics);
   }
 
   final boolean baseEquals(JobStatistics jobStatistics) {
@@ -844,6 +1102,9 @@ public abstract class JobStatistics implements Serializable {
     statistics.setCreationTime(creationTime);
     statistics.setEndTime(endTime);
     statistics.setStartTime(startTime);
+    statistics.setNumChildJobs(numChildJobs);
+    statistics.setParentJobId(parentJobId);
+    statistics.setScriptStatistics(scriptStatistics.toPb());
     return statistics;
   }
 

--- a/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
+++ b/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
@@ -45,6 +45,7 @@ public interface BigQueryRpc extends ServiceRpc {
     MAX_CREATION_TIME("maxCreationTime"),
     MAX_RESULTS("maxResults"),
     PAGE_TOKEN("pageToken"),
+    PARENT_JOB_ID("parentJobId"),
     START_INDEX("startIndex"),
     STATE_FILTER("stateFilter"),
     TIMEOUT("timeoutMs");


### PR DESCRIPTION
 Need to implement some incremental changes to enable scripting support in the BigQuery library.

- Jobs (e.g. scripts) can create child jobs. There's new stats on the Job Statistics like numChildJobs (for the parent), and parentJobId (for the children). There's also a new enum for the statementType (SCRIPT).

- bigquery.jobs.list now supports passing an option to filter by parentJobId.
 
- JobStatistics now may include ScriptStatistics message, which itself may also contain ScriptStackFrame information.